### PR TITLE
0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change log of DVH Analytics
 
-v0.6.6 (TBD)
+v0.6.6 (2020.01.09)
 --------------------
  - [About] Fix bug that displayed version of last options save instead of currently installed version
-
+ - [Endpoints] ensure extra_column_data values do not have commas, issue [20](https://github.com/cutright/DVH-Analytics/issues/20)
+ - [Time Series] Prevent crash if simulatation date is not able to be parsed by dateutil
 
 v0.6.5 (2020.01.08)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log of DVH Analytics
 
+v0.6.6 (TBD)
+--------------------
+ - [About] Fix bug that displayed version of last options save instead of currently installed version
+
+
 v0.6.5 (2020.01.08)
 --------------------
  - [Correlation] New tab added showing a correlation matrix

--- a/dvha/dialogs/main.py
+++ b/dvha/dialogs/main.py
@@ -19,7 +19,7 @@ from dvha.tools.utilities import get_selected_listctrl_items, MessageDialog, get
 from dvha.db import sql_columns
 from dvha.db.sql_connector import DVH_SQL
 from dvha.paths import IMPORT_SETTINGS_PATH, parse_settings_file, LICENSE_PATH
-from dvha.options import Options
+from dvha.options import Options, DefaultOptions
 
 
 class DatePicker(wx.Dialog):
@@ -949,7 +949,7 @@ class About(wx.Dialog):
         with open(LICENSE_PATH, 'r') as license_file:
             license_text = ''.join([line for line in license_file])
 
-        license_text = "DVH Analytics v%s\ndvhanalytics.com\n\n%s" % (Options().VERSION, license_text)
+        license_text = "DVH Analytics v%s\ndvhanalytics.com\n\n%s" % (DefaultOptions().VERSION, license_text)
 
         sizer_wrapper = wx.BoxSizer(wx.VERTICAL)
         sizer_text = wx.BoxSizer(wx.VERTICAL)

--- a/dvha/models/data_table.py
+++ b/dvha/models/data_table.py
@@ -364,7 +364,7 @@ class DataTable:
         """
         columns_dict_value['data'].insert(0, columns_dict_value['title'])
         for i, row in enumerate(data_for_csv):
-            row.insert(index, columns_dict_value['data'][i])
+            row.insert(index, str(columns_dict_value['data'][i]).replace(',', ';'))
 
     def insert_columns_into_data_for_csv(self, data_for_csv, columns_dict):
         """

--- a/dvha/models/time_series.py
+++ b/dvha/models/time_series.py
@@ -11,7 +11,7 @@ Class for viewing and editing the roi map, and updating the database with change
 #    available at https://github.com/cutright/DVH-Analytics
 
 import wx
-from dateutil import parser
+from dateutil.parser import parse as date_parser
 from dvha.db import sql_columns
 from dvha.dialogs.export import save_data_to_file
 from dvha.models.plot import PlotTimeSeries
@@ -131,7 +131,11 @@ class TimeSeriesFrame:
                 x_values_sorted, y_values_sorted, mrn_sorted, uid_sorted = [], [], [], []
 
                 for s in range(len(x_data)):
-                    x_values_sorted.append(parser.parse(x_data[sort_index[s]]))
+                    try:
+                        x = date_parser(x_data[sort_index[s]])
+                    except:
+                        continue
+                    x_values_sorted.append(x)
                     y_values_sorted.append(y_data[sort_index[s]])
                     mrn_sorted.append(stats_data.mrns[sort_index[s]])
                     uid_sorted.append(stats_data.uids[sort_index[s]])

--- a/dvha/options.py
+++ b/dvha/options.py
@@ -22,7 +22,7 @@ class DefaultOptions:
     Create default options, to be inherited by Options class
     """
     def __init__(self):
-        self.VERSION = '0.6.5'
+        self.VERSION = '0.6.6'
 
         self.MIN_BORDER = 50
 


### PR DESCRIPTION
v0.6.6 (2020.01.09)
--------------------
 - [About] Fix bug that displayed version of last options save instead of currently installed version
 - [Endpoints] ensure extra_column_data values do not have commas, issue [20](https://github.com/cutright/DVH-Analytics/issues/20)
 - [Time Series] Prevent crash if simulatation date is not able to be parsed by dateutil
