### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Dependencies
 * [Statsmodels](https://github.com/statsmodels/statsmodels) >=0.8.0
 * [Scikit-learn](http://scikit-learn.org) >= 0.21.0
 * [regressors](https://pypi.org/project/regressors/)
-* [FuzzyWuzzy](https://github.com/seatgeek/fuzzywuzzy)
+* [RapidFuzz](https://github.com/rhasspy/rapidfuzz)
 
 
 Support

--- a/dvha/tools/name_prediction.py
+++ b/dvha/tools/name_prediction.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from dvha.tools.roi_name_manager import clean_name
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ python-dateutil
 statsmodels >= 0.8.0
 scikit-learn>=0.21.0
 regressors
-fuzzywuzzy
+rapidfuzz


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy (with python-Levenshtein).
RapidFuzz provides [prebuild wheels](https://pypi.org/project/rapidfuzz/0.2.1/#files) so it is not required to compile it on the target device