### PR TITLE
V0.7.9dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 v0.7.9 (TBD)
 --------------------
  - [Misc] Remove references to the deprecated import_settings.txt file
+ - [ROI Map] Fix GH Issue [75](https://github.com/cutright/DVH-Analytics/issues/75)
+ - [ROI Map] Deleting a physician in the ROI Map module now actually deletes the .roi file stored locally
 
 v0.7.8 (2020.05.01)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v0.7.9 (TBD)
  - [Misc] Remove references to the deprecated import_settings.txt file
  - [ROI Map] Fix GH Issue [75](https://github.com/cutright/DVH-Analytics/issues/75)
  - [ROI Map] Deleting a physician in the ROI Map module now actually deletes the .roi file stored locally
+ - [ROI Map] Alert user on ROI Map frame close that ROI Map won't be saved when using the OS's window close button
 
 v0.7.8 (2020.05.01)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ v0.7.9 (TBD)
  - [ROI Map] Fix GH Issue [75](https://github.com/cutright/DVH-Analytics/issues/75)
  - [ROI Map] Deleting a physician in the ROI Map module now actually deletes the .roi file stored locally
  - [ROI Map] Alert user on ROI Map frame close that ROI Map won't be saved when using the OS's window close button
+ - [ROI Map] Bug fix for editing physician name
+ - [ROI Map] Bug fix for validating new physician name
 
 v0.7.8 (2020.05.01)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ v0.7.9 (TBD)
  - [ROI Map] Fix GH Issue [75](https://github.com/cutright/DVH-Analytics/issues/75)
  - [ROI Map] Deleting a physician in the ROI Map module now actually deletes the .roi file stored locally
  - [ROI Map] Alert user on ROI Map frame close that ROI Map won't be saved when using the OS's window close button
- - [ROI Map] Bug fix for editing physician name
+ - [ROI Map] Prevent TypeError on editing physician name
  - [ROI Map] Bug fix for validating new physician name
 
 v0.7.8 (2020.05.01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log of DVH Analytics
 
+v0.7.9 (TBD)
+--------------------
+ - [Misc] Remove references to the deprecated import_settings.txt file
+
 v0.7.8 (2020.05.01)
 --------------------
  - [Import] Only allow `DoseSummationType` of `PLAN` or `BRACHY` if multiple dose files are found 

--- a/dvha/_version.py
+++ b/dvha/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.7.8'
+__version__ = '0.7.9dev'

--- a/dvha/dialogs/roi_map.py
+++ b/dvha/dialogs/roi_map.py
@@ -321,29 +321,23 @@ class RoiManager(wx.Dialog):
 
     def update_physicians(self, old_physicians=None):
         choices = list(self.roi_map.physicians)
-        if choices:
-            new = choices[0]
-            if old_physicians:
-                new = list(set(choices) - set(old_physicians))
-
-            self.update_combo_box_choices(self.combo_box_physician, choices, new)
+        self.update_combo_box_choices(self.combo_box_physician, choices, old_physicians)
 
     def update_physician_rois(self, old_physician_rois=None):
         choices = self.roi_map.get_physician_rois(self.physician)
-        if choices:
-            new = choices[0]
-            if old_physician_rois:
-                new = list(set(choices) - set(old_physician_rois))
-
-            self.update_combo_box_choices(self.combo_box_physician_roi, choices, new)
+        self.update_combo_box_choices(self.combo_box_physician_roi, choices, old_physician_rois)
 
     @staticmethod
-    def update_combo_box_choices(combo_box, choices, value):
-        if not value:
-            value = combo_box.GetValue()
-        combo_box.Clear()
-        combo_box.AppendItems(choices)
-        combo_box.SetValue(value)
+    def update_combo_box_choices(combo_box, choices, old_choices):
+        if choices:
+            value = choices[0]
+            if old_choices:
+                value = list(set(choices) - set(old_choices))
+                value = value[0] if len(value) else combo_box.GetValue()
+
+            combo_box.Clear()
+            combo_box.AppendItems(choices)
+            combo_box.SetValue(value)
 
     def update_variations(self):
         self.data_table.set_data(self.variation_table_data, self.columns)

--- a/dvha/dialogs/roi_map.py
+++ b/dvha/dialogs/roi_map.py
@@ -99,7 +99,8 @@ class AddPhysician(wx.Dialog):
             # self.roi_map.add_physician(self.text_ctrl_physician.GetValue(), add_institutional_rois=False)
             physician = self.text_ctrl_physician.GetValue()
             dlg = TG263Dialog(physician, self.roi_map)
-            self.roi_map.import_physician_roi_map(dlg.map_file_path)
+            if dlg.map_file_path is not None:
+                self.roi_map.import_physician_roi_map(dlg.map_file_path)
 
         else:
             self.roi_map.copy_physician(self.text_ctrl_physician.GetValue(),

--- a/dvha/models/roi_map.py
+++ b/dvha/models/roi_map.py
@@ -589,7 +589,7 @@ class ROIMapFrame(wx.Frame):
         self.update_roi_map()
 
     def on_edit_physician(self, evt):
-        current_physicians = list(self.roi_map.get_physicians)
+        current_physicians = list(self.roi_map.get_physicians())
         dlg = RenamePhysicianDialog(self.physician, self.roi_map)
         if dlg.res == wx.ID_OK:
             self.update_all(old_physicians=current_physicians)

--- a/dvha/models/roi_map.py
+++ b/dvha/models/roi_map.py
@@ -692,6 +692,9 @@ class ROIMapFrame(wx.Frame):
         self.update_physicians()
 
     def on_close(self, *args):
+        MessageDialog(self, 'Close without saving ROI Map?', action_yes_func=self.do_close)
+
+    def do_close(self):
         self.Destroy()
         self.roi_map.import_from_file()
         self.physicians_to_delete = []

--- a/dvha/paths.py
+++ b/dvha/paths.py
@@ -36,7 +36,6 @@ DIRECTORIES = {key[:-4]: value for key, value in locals().items() if key.endswit
 
 OPTIONS_PATH = join(PREF_DIR, '.options')
 OPTIONS_CHECKSUM_PATH = join(PREF_DIR, '.options_checksum')
-IMPORT_SETTINGS_PATH = join(PREF_DIR, 'import_settings.txt')
 SQL_CNF_PATH = join(PREF_DIR, 'sql_connection.cnf')
 LICENSE_PATH = join(PARENT_DIR, 'LICENSE.txt')
 CREATE_PGSQL_TABLES = join(SCRIPT_DIR, 'db', 'create_tables.sql')

--- a/dvha/tools/roi_map_generator.py
+++ b/dvha/tools/roi_map_generator.py
@@ -79,7 +79,7 @@ class ROIMapGenerator:
         """
 
         for key in list(data_filter):
-            if data_filter[key].lower() == 'all':
+            if not isinstance(data_filter[key], list) and data_filter[key].lower() == 'all':
                 data_filter.pop(key)
 
         data = {key: [] for key in self.keys}

--- a/dvha/tools/roi_name_manager.py
+++ b/dvha/tools/roi_name_manager.py
@@ -18,7 +18,7 @@ from dvha.db.sql_to_python import QuerySQL
 from dvha.db.sql_connector import DVH_SQL
 from dvha.paths import PREF_DIR
 from dvha.tools.roi_map_generator import ROIMapGenerator
-from dvha.tools.utilities import flatten_list_of_lists, initialize_directories
+from dvha.tools.utilities import flatten_list_of_lists, initialize_directories, delete_file
 
 
 class PhysicianROI:
@@ -290,6 +290,10 @@ class DatabaseROIs:
     def delete_physician(self, physician):
         if physician in list(self.physicians):
             self.physicians.pop(physician, None)
+
+            rel_path = 'physician_%s.roi' % physician
+            abs_file_path = os.path.join(PREF_DIR, rel_path)
+            delete_file(abs_file_path)
 
     def is_physician(self, physician):
         return physician in list(self.physicians)

--- a/dvha/tools/roi_name_manager.py
+++ b/dvha/tools/roi_name_manager.py
@@ -18,7 +18,7 @@ from dvha.db.sql_to_python import QuerySQL
 from dvha.db.sql_connector import DVH_SQL
 from dvha.paths import PREF_DIR
 from dvha.tools.roi_map_generator import ROIMapGenerator
-from dvha.tools.utilities import flatten_list_of_lists, initialize_directories, delete_file
+from dvha.tools.utilities import flatten_list_of_lists, initialize_directories
 
 
 class PhysicianROI:
@@ -202,12 +202,12 @@ class DatabaseROIs:
         if not os.path.isdir(PREF_DIR):
             initialize_directories()
 
-        self.physicians_from_file = get_physicians_from_roi_files()
-
+        self.physicians_from_file = None
         self.branched_institutional_rois = {}
         self.import_from_file()
 
     def import_from_file(self):
+        self.physicians_from_file = get_physicians_from_roi_files()
         self.physicians = {}
         self.institutional_rois = []
 
@@ -290,10 +290,6 @@ class DatabaseROIs:
     def delete_physician(self, physician):
         if physician in list(self.physicians):
             self.physicians.pop(physician, None)
-
-            rel_path = 'physician_%s.roi' % physician
-            abs_file_path = os.path.join(PREF_DIR, rel_path)
-            delete_file(abs_file_path)
 
     def is_physician(self, physician):
         return physician in list(self.physicians)

--- a/dvha/tools/utilities.py
+++ b/dvha/tools/utilities.py
@@ -54,16 +54,6 @@ def initialize_directories():
     for directory in DIRECTORIES.values():
         if not isdir(directory):
             mkdir(directory)
-    initialize_protocols()
-
-
-def initialize_protocols():
-    """If no protocols are found in PROTOCOL_DIR, copy defaults"""
-    current_protocols = [f for f in listdir(DIRECTORIES['PROTOCOL']) if splitext(f)[1].lower() == '.scp']
-    if not current_protocols:
-        file_names = [f for f in listdir(DIRECTORIES['PROTOCOL_DEFAULT']) if splitext(f)[1].lower() == '.scp']
-        file_paths = [join(DIRECTORIES['PROTOCOL_DEFAULT'], f) for f in file_names]
-        move_files_to_new_path(file_paths, DIRECTORIES['PROTOCOL'], copy_files=True)
 
 
 def write_sql_connection_settings(config):


### PR DESCRIPTION
v0.7.9 (TBD)
--------------------
 - [Misc] Remove references to the deprecated import_settings.txt file
 - [ROI Map] Fix GH Issue [75](https://github.com/cutright/DVH-Analytics/issues/75)
 - [ROI Map] Deleting a physician in the ROI Map module now actually deletes the .roi file stored locally

**Update**: the following has been resolved with 2d83fdb
There is still a small bug.  If you delete a Physician in the ROI Map that existed at application launch, the key in `roi_map.physicians` is not removed, but the data is gone.  If you delete a physician that was created during your ROI Map frame session, the deletion sticks.

Current work around. Restart DVHA after deleting a physician.  But hopefully I'll resolve this before `v0.7.9` release tomorrow.