### PR TITLE
v0.8.9.post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log of DVH Analytics
 
+v0.8.9.post1 (2020.11.16)
+--------------------
+ - [Import] Resolved bug where empty ROI slice crashed DTH calculation [Issue 113](https://github.com/cutright/DVH-Analytics/issues/113)
+
 v0.8.9 (2020.11.15)
 --------------------
  - [Import] Importing DICOM-RT Dose file no longer causes crash if no matching Plan is found [Issue 105](https://github.com/cutright/DVH-Analytics/issues/105)

--- a/dvha/_version.py
+++ b/dvha/_version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.9'
+__version__ = '0.8.9.post1'

--- a/dvha/db/update.py
+++ b/dvha/db/update.py
@@ -118,7 +118,7 @@ def min_distances(study_instance_uid, roi_name, pre_calc=None):
     try:
         is_inside = [[1, -1][roi_geom.is_point_inside_roi(point, treatment_volume_roi)] for point in oar_coordinates]
         data = roi_geom.min_distances_to_target(oar_coordinates, treatment_volume_coord, factors=is_inside)
-    except MemoryError:
+    except Exception:
         try:
             treatment_volume_coord = sample_roi(treatment_volume_coord, max_point_count=3000)
             oar_coordinates = sample_roi(oar_coordinates,  max_point_count=3000)

--- a/dvha/tools/roi_geometry.py
+++ b/dvha/tools/roi_geometry.py
@@ -120,9 +120,11 @@ def is_point_inside_roi(point, roi):
     if np.max(roi_z) > point[2] > np.min(roi_z):
         nearest_z_index = (np.abs(roi_z - point[2])).argmin()
         nearest_z_key = z_keys[nearest_z_index]
-        shapely_roi = points_to_shapely_polygon(roi[nearest_z_key])
-        shapely_point = Point(point[0], point[1])
-        return shapely_point.within(shapely_roi)
+        if abs(float(nearest_z_key) - point[2]) < 0.5:  # make sure point is within 0.5mm
+            if len(roi[nearest_z_key]) > 2:  # make sure there are 3 points to make a polygon
+                shapely_roi = points_to_shapely_polygon(roi[nearest_z_key])
+                shapely_point = Point(point[0], point[1])
+                return shapely_point.within(shapely_roi)
     return False
 
 


### PR DESCRIPTION
v0.8.9.post1 (2020.11.16)
--------------------
 - [Import] Resolved bug where empty ROI slice crashed DTH calculation [Issue 113](https://github.com/cutright/DVH-Analytics/issues/113)
